### PR TITLE
Add count API for DNS batch record changes

### DIFF
--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeService.scala
@@ -622,6 +622,28 @@ class BatchChangeService(
     } yield listWithGroupNames
   }
 
+  def getBatchChangeCount(
+      auth: AuthPrincipal,
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      ignoreAccess: Boolean = false,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): BatchResult[BatchChangeCount] = {
+    val userId = if (ignoreAccess && auth.isSystemAdmin) None else Some(auth.userId)
+    val submitterUserName =
+      if (userName.isDefined && userName.get.isEmpty) None else userName
+    val startDateTime =
+      if (dateTimeStartRange.isDefined && dateTimeStartRange.get.isEmpty) None
+      else dateTimeStartRange
+    val endDateTime =
+      if (dateTimeEndRange.isDefined && dateTimeEndRange.get.isEmpty) None
+      else dateTimeEndRange
+    batchChangeRepo
+      .getBatchChangeCount(userId, submitterUserName, startDateTime, endDateTime, approvalStatus)
+      .toBatchResult
+  }
+
   def rejectBatchChange(
       batchChange: BatchChange,
       reviewComment: Option[String],

--- a/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
+++ b/modules/api/src/main/scala/vinyldns/api/domain/batch/BatchChangeServiceAlgebra.scala
@@ -20,7 +20,7 @@ import vinyldns.api.domain.batch.BatchChangeInterfaces.BatchResult
 import vinyldns.core.domain.auth.AuthPrincipal
 import vinyldns.core.domain.batch.BatchChangeApprovalStatus.BatchChangeApprovalStatus
 import vinyldns.core.domain.batch.BatchChangeStatus.BatchChangeStatus
-import vinyldns.core.domain.batch.{BatchChange, BatchChangeInfo, BatchChangeSummaryList}
+import vinyldns.core.domain.batch.{BatchChange, BatchChangeCount, BatchChangeInfo, BatchChangeSummaryList}
 
 // $COVERAGE-OFF$
 trait BatchChangeServiceAlgebra {
@@ -43,6 +43,15 @@ trait BatchChangeServiceAlgebra {
       batchStatus: Option[BatchChangeStatus],
       approvalStatus: Option[BatchChangeApprovalStatus]
   ): BatchResult[BatchChangeSummaryList]
+
+  def getBatchChangeCount(
+      auth: AuthPrincipal,
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      ignoreAccess: Boolean = false,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): BatchResult[BatchChangeCount]
 
   def rejectBatchChange(
       batchChangeId: String,

--- a/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
+++ b/modules/api/src/main/scala/vinyldns/api/route/BatchChangeRouting.scala
@@ -119,6 +119,41 @@ class BatchChangeRoute(
             }
         }
       } ~
+      path("zones" / "batchrecordchanges" / "count") {
+        (get & monitor("Endpoint.getBatchChangeCount")) {
+          parameters(
+            "userName".as[String].?,
+            "dateTimeRangeStart".as[String].?,
+            "dateTimeRangeEnd".as[String].?,
+            "ignoreAccess".as[Boolean].?(false),
+            "approvalStatus".as[String].?
+          ) {
+            (
+                userName: Option[String],
+                dateTimeRangeStart: Option[String],
+                dateTimeRangeEnd: Option[String],
+                ignoreAccess: Boolean,
+                approvalStatus: Option[String]
+            ) =>
+              {
+                val convertApprovalStatus =
+                  approvalStatus.flatMap(BatchChangeApprovalStatus.find)
+                authenticateAndExecute(
+                  batchChangeService.getBatchChangeCount(
+                    _,
+                    userName,
+                    dateTimeRangeStart,
+                    dateTimeRangeEnd,
+                    ignoreAccess,
+                    convertApprovalStatus
+                  )
+                ) { result =>
+                  complete(StatusCodes.OK, result)
+                }
+              }
+          }
+        }
+      } ~
       path("zones" / "batchrecordchanges" / Segment) { id =>
         (get & monitor("Endpoint.getBatchChange")) {
           authenticateAndExecute(batchChangeService.getBatchChange(id, _)) { chg =>

--- a/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/domain/batch/BatchChangeServiceSpec.scala
@@ -2579,6 +2579,221 @@ class BatchChangeServiceSpec
     }
   }
 
+  "getBatchChangeCount" should {
+    def saveBatch(
+        ownerAuth: AuthPrincipal,
+        approvalStatus: BatchChangeApprovalStatus.BatchChangeApprovalStatus,
+        offsetMillis: Long = 0L,
+        userNameOverride: Option[String] = None
+    ): BatchChange = {
+      val bc = BatchChange(
+        ownerAuth.userId,
+        userNameOverride.getOrElse(ownerAuth.signedInUser.userName),
+        None,
+        Instant.ofEpochMilli(Instant.now.truncatedTo(ChronoUnit.MILLIS).toEpochMilli + offsetMillis),
+        List(),
+        approvalStatus = approvalStatus
+      )
+      batchChangeRepo.save(bc).unsafeRunSync()
+      bc
+    }
+
+    "return zero counts when the user has no batch changes" in {
+      val result = underTest.getBatchChangeCount(auth).value.unsafeRunSync().toOption.get
+
+      result.total shouldBe 0
+      result.complete shouldBe 0
+      result.failed shouldBe 0
+      result.partialFailure shouldBe 0
+      result.rejected shouldBe 0
+      result.cancelled shouldBe 0
+      result.pendingReview shouldBe 0
+      result.scheduled shouldBe 0
+      result.pendingProcessing shouldBe 0
+    }
+
+    "return counts grouped by status for the authenticated user's batch changes" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+      saveBatch(auth, BatchChangeApprovalStatus.ManuallyRejected, offsetMillis = 3)
+      saveBatch(auth, BatchChangeApprovalStatus.Cancelled, offsetMillis = 4)
+
+      val result = underTest.getBatchChangeCount(auth).value.unsafeRunSync().toOption.get
+
+      // AutoApproved with no changes derives to Complete
+      result.complete shouldBe 2
+      result.pendingReview shouldBe 1
+      result.rejected shouldBe 1
+      result.cancelled shouldBe 1
+      result.failed shouldBe 0
+      result.partialFailure shouldBe 0
+      result.scheduled shouldBe 0
+      result.pendingProcessing shouldBe 0
+      result.total shouldBe 5
+    }
+
+    "exclude other users' batch changes when ignoreAccess is false" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(notAuth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+      saveBatch(notAuth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+
+      val result = underTest.getBatchChangeCount(auth).value.unsafeRunSync().toOption.get
+
+      result.total shouldBe 1
+      result.complete shouldBe 1
+    }
+
+    "return counts for all users when ignoreAccess is true and the requester is a system admin" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(notAuth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+      saveBatch(notAuth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+
+      val result =
+        underTest
+          .getBatchChangeCount(superUserAuth, ignoreAccess = true)
+          .value
+          .unsafeRunSync()
+          .toOption
+          .get
+
+      result.total shouldBe 3
+      result.complete shouldBe 2
+      result.pendingReview shouldBe 1
+    }
+
+    "scope counts to the requester's own batches when ignoreAccess is true but requester is not a system admin" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(notAuth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+
+      val result =
+        underTest
+          .getBatchChangeCount(auth, ignoreAccess = true)
+          .value
+          .unsafeRunSync()
+          .toOption
+          .get
+
+      result.total shouldBe 1
+      result.complete shouldBe 1
+    }
+
+    "filter counts by approvalStatus when provided" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 1)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 2)
+
+      val result = underTest
+        .getBatchChangeCount(
+          auth,
+          approvalStatus = Some(BatchChangeApprovalStatus.PendingReview)
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 2
+      result.pendingReview shouldBe 2
+      result.complete shouldBe 0
+    }
+
+    "filter counts by userName when provided" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(
+        auth,
+        BatchChangeApprovalStatus.AutoApproved,
+        offsetMillis = 1,
+        userNameOverride = Some("anotherUser")
+      )
+
+      val result = underTest
+        .getBatchChangeCount(superUserAuth, userName = Some("anotherUser"), ignoreAccess = true)
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 1
+      result.complete shouldBe 1
+    }
+
+    "normalize an empty-string userName to no filter" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.PendingReview, offsetMillis = 1)
+
+      val result = underTest
+        .getBatchChangeCount(auth, userName = Some(""))
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 2
+    }
+
+    "normalize empty-string date range bounds to no filter" in {
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved)
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 1)
+
+      val result = underTest
+        .getBatchChangeCount(
+          auth,
+          dateTimeStartRange = Some(""),
+          dateTimeEndRange = Some("")
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      result.total shouldBe 2
+    }
+
+    "filter counts by an inclusive date range when provided" in {
+      val now = Instant.now.truncatedTo(ChronoUnit.MILLIS)
+      val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+      // saved batch is in the future; range bounded to a past window should exclude it
+      saveBatch(auth, BatchChangeApprovalStatus.AutoApproved, offsetMillis = 60000L)
+
+      val past =
+        LocalDateTime.ofInstant(now.minusSeconds(120), ZoneId.of("UTC")).format(formatter)
+      val pastEnd =
+        LocalDateTime.ofInstant(now.minusSeconds(60), ZoneId.of("UTC")).format(formatter)
+
+      val excluded = underTest
+        .getBatchChangeCount(
+          auth,
+          dateTimeStartRange = Some(past),
+          dateTimeEndRange = Some(pastEnd)
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      excluded.total shouldBe 0
+
+      // open-ended range encompassing the saved batch should include it
+      val futureEnd =
+        LocalDateTime.ofInstant(now.plusSeconds(600), ZoneId.of("UTC")).format(formatter)
+
+      val included = underTest
+        .getBatchChangeCount(
+          auth,
+          dateTimeStartRange = Some(past),
+          dateTimeEndRange = Some(futureEnd)
+        )
+        .value
+        .unsafeRunSync()
+        .toOption
+        .get
+
+      included.total shouldBe 1
+      included.complete shouldBe 1
+    }
+  }
+
   "getOwnerGroup" should {
     "return None if owner group ID is None" in {
       underTest.getOwnerGroup(None).value.unsafeRunSync().toOption.get shouldBe None

--- a/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
+++ b/modules/api/src/test/scala/vinyldns/api/repository/InMemoryBatchChangeRepository.scala
@@ -180,4 +180,70 @@ class InMemoryBatchChangeRepository extends BatchChangeRepository {
     batches.clear()
     singleChangesMap.clear()
   }
+
+  def getBatchChangeCount(
+      userId: Option[String],
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): IO[BatchChangeCount] = {
+    val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+    val startInstant = dateTimeStartRange.map(dt =>
+      LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant
+    )
+    val endInstant = dateTimeEndRange.map(dt =>
+      LocalDateTime.parse(dt, formatter).atZone(ZoneId.of("UTC")).toInstant
+    )
+
+    val filtered = batches.values.toList
+      .filter(b => userId.forall(_ == b.userId))
+      .filter(b => userName.forall(_ == b.userName))
+      .filter(b => startInstant.forall(_.isBefore(b.createdTimestamp)))
+      .filter(b => endInstant.forall(_.isAfter(b.createdTimestamp)))
+      .filter(b => approvalStatus.forall(_ == b.approvalStatus))
+
+    val statuses: List[BatchChangeStatus] = filtered.map { sc =>
+      val changes = sc.changes.flatMap(singleChangesMap.get)
+      BatchChange(
+        sc.userId,
+        sc.userName,
+        sc.comments,
+        sc.createdTimestamp,
+        changes,
+        sc.ownerGroupId,
+        sc.approvalStatus,
+        sc.reviewerId,
+        sc.reviewComment,
+        sc.reviewTimestamp,
+        sc.id
+      ).status
+    }
+
+    def cnt(s: BatchChangeStatus): Int = statuses.count(_ == s)
+
+    val complete          = cnt(BatchChangeStatus.Complete)
+    val failed            = cnt(BatchChangeStatus.Failed)
+    val partialFailure    = cnt(BatchChangeStatus.PartialFailure)
+    val rejected          = cnt(BatchChangeStatus.Rejected)
+    val cancelled         = cnt(BatchChangeStatus.Cancelled)
+    val pendingReview     = cnt(BatchChangeStatus.PendingReview)
+    val scheduled         = cnt(BatchChangeStatus.Scheduled)
+    val pendingProcessing = cnt(BatchChangeStatus.PendingProcessing)
+
+    IO.pure(
+      BatchChangeCount(
+        total = complete + failed + partialFailure + rejected +
+          cancelled + pendingReview + scheduled + pendingProcessing,
+        complete = complete,
+        failed = failed,
+        partialFailure = partialFailure,
+        rejected = rejected,
+        cancelled = cancelled,
+        pendingReview = pendingReview,
+        scheduled = scheduled,
+        pendingProcessing = pendingProcessing
+      )
+    )
+  }
 }

--- a/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
+++ b/modules/api/src/test/scala/vinyldns/api/route/BatchChangeRoutingSpec.scala
@@ -488,6 +488,63 @@ class BatchChangeRoutingSpec()
         case ("batchId", _) => EitherT(IO.pure(BatchChangeNotPendingReview("batchId").asLeft))
         case (_, _) => EitherT(IO.pure(BatchChangeNotFound("notFoundId").asLeft))
       }
+
+    def getBatchChangeCount(
+        auth: AuthPrincipal,
+        userName: Option[String] = None,
+        dateTimeStartRange: Option[String] = None,
+        dateTimeEndRange: Option[String] = None,
+        ignoreAccess: Boolean = false,
+        approvalStatus: Option[BatchChangeApprovalStatus] = None
+    ): EitherT[IO, BatchChangeErrorResponse, BatchChangeCount] =
+      (auth.userId, ignoreAccess, approvalStatus, userName, dateTimeStartRange, dateTimeEndRange) match {
+        case (okAuth.userId, false, None, None, None, None) =>
+          EitherT.rightT(
+            BatchChangeCount(
+              total = 4,
+              complete = 2,
+              failed = 0,
+              partialFailure = 0,
+              rejected = 0,
+              cancelled = 0,
+              pendingReview = 1,
+              scheduled = 0,
+              pendingProcessing = 1
+            )
+          )
+        case (okAuth.userId, false, Some(BatchChangeApprovalStatus.PendingReview), None, None, None) =>
+          EitherT.rightT(
+            BatchChangeCount(total = 1, pendingReview = 1)
+          )
+        case (
+            okAuth.userId,
+            false,
+            None,
+            Some(uname),
+            Some("2023-11-14 00:00:00"),
+            Some("2023-11-15 00:00:00")
+            ) if uname == okAuth.signedInUser.userName =>
+          EitherT.rightT(BatchChangeCount(total = 1, complete = 1))
+        case (superUserAuth.userId, true, None, None, None, None) =>
+          EitherT.rightT(
+            BatchChangeCount(
+              total = 7,
+              complete = 3,
+              failed = 1,
+              partialFailure = 1,
+              rejected = 1,
+              cancelled = 0,
+              pendingReview = 1,
+              scheduled = 0,
+              pendingProcessing = 0
+            )
+          )
+        case (superUserAuth.userId, true, Some(BatchChangeApprovalStatus.PendingReview), None, None, None) =>
+          EitherT.rightT(BatchChangeCount(total = 2, pendingReview = 2))
+        case (superUserAuth.userId, false, _, _, _, _) =>
+          EitherT.rightT(BatchChangeCount())
+        case _ => EitherT.rightT(BatchChangeCount())
+      }
   }
 
   "POST batch change" should {
@@ -793,6 +850,121 @@ class BatchChangeRoutingSpec()
         resp.nextId shouldBe None
         resp.ignoreAccess shouldBe true
         resp.approvalStatus.toString shouldBe Some(BatchChangeApprovalStatus.PendingReview).toString
+      }
+    }
+  }
+
+  "GET batch change count" should {
+    "return the count grouped by status for the authenticated user" in {
+      Get("/zones/batchrecordchanges/count") ~> batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 4
+        resp.complete shouldBe 2
+        resp.failed shouldBe 0
+        resp.partialFailure shouldBe 0
+        resp.rejected shouldBe 0
+        resp.cancelled shouldBe 0
+        resp.pendingReview shouldBe 1
+        resp.scheduled shouldBe 0
+        resp.pendingProcessing shouldBe 1
+      }
+    }
+
+    "filter the count by approvalStatus query param" in {
+      Get("/zones/batchrecordchanges/count?approvalStatus=PendingReview") ~>
+        batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 1
+        resp.pendingReview shouldBe 1
+        resp.complete shouldBe 0
+      }
+    }
+
+    "filter the count by userName and date range query params" in {
+      val url =
+        s"/zones/batchrecordchanges/count?userName=${okAuth.signedInUser.userName}" +
+          "&dateTimeRangeStart=2023-11-14%2000:00:00" +
+          "&dateTimeRangeEnd=2023-11-15%2000:00:00"
+
+      Get(url) ~> batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 1
+        resp.complete shouldBe 1
+      }
+    }
+
+    "return the count across all users when ignoreAccess is true and requester is a super user" in {
+      Get("/zones/batchrecordchanges/count?ignoreAccess=true") ~>
+        superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 7
+        resp.complete shouldBe 3
+        resp.failed shouldBe 1
+        resp.partialFailure shouldBe 1
+        resp.rejected shouldBe 1
+        resp.pendingReview shouldBe 1
+      }
+    }
+
+    "filter by approvalStatus when ignoreAccess is true and requester is a super user" in {
+      Get("/zones/batchrecordchanges/count?ignoreAccess=true&approvalStatus=PendingReview") ~>
+        superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 2
+        resp.pendingReview shouldBe 2
+      }
+    }
+
+    "default ignoreAccess to false when omitted" in {
+      // super user with no ignoreAccess param should not get the cross-user totals
+      Get("/zones/batchrecordchanges/count") ~> superUserRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 0
+      }
+    }
+
+    "ignore an unrecognized approvalStatus value (falls through to no filter)" in {
+      Get("/zones/batchrecordchanges/count?approvalStatus=NotAStatus") ~>
+        batchChangeRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        // Same as the no-filter case for okAuth
+        resp.total shouldBe 4
+        resp.complete shouldBe 2
+        resp.pendingReview shouldBe 1
+        resp.pendingProcessing shouldBe 1
+      }
+    }
+
+    "return zero counts for an unrelated authenticated user" in {
+      Get("/zones/batchrecordchanges/count") ~> notAuthRoute ~> check {
+        status shouldBe OK
+
+        val resp = responseAs[BatchChangeCount]
+
+        resp.total shouldBe 0
+        resp.complete shouldBe 0
+        resp.pendingReview shouldBe 0
       }
     }
   }

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeRepository.scala
@@ -39,6 +39,14 @@ trait BatchChangeRepository extends Repository {
       approvalStatus: Option[BatchChangeApprovalStatus] = None
   ): IO[BatchChangeSummaryList]
 
+  def getBatchChangeCount(
+      userId: Option[String],
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): IO[BatchChangeCount]
+
   // updateSingleChanges updates status, recordSetId, recordChangeId and systemMessage (in data).
   def updateSingleChanges(singleChanges: List[SingleChange]): IO[Option[BatchChange]]
 

--- a/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
+++ b/modules/core/src/main/scala/vinyldns/core/domain/batch/BatchChangeSummary.scala
@@ -97,3 +97,15 @@ case class BatchChangeSummaryList(
     dateTimeStartRange: Option[String] = None,
     dateTimeEndRange: Option[String] = None,
 )
+
+case class BatchChangeCount(
+    total: Int = 0,
+    complete: Int = 0,
+    failed: Int = 0,
+    partialFailure: Int = 0,
+    rejected: Int = 0,
+    cancelled: Int = 0,
+    pendingReview: Int = 0,
+    scheduled: Int = 0,
+    pendingProcessing: Int = 0
+)

--- a/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
+++ b/modules/mysql/src/main/scala/vinyldns/mysql/repository/MySqlBatchChangeRepository.scala
@@ -255,6 +255,63 @@ class MySqlBatchChangeRepository
       }
     }
 
+  def getBatchChangeCount(
+      userId: Option[String],
+      userName: Option[String] = None,
+      dateTimeStartRange: Option[String] = None,
+      dateTimeEndRange: Option[String] = None,
+      approvalStatus: Option[BatchChangeApprovalStatus] = None
+  ): IO[BatchChangeCount] =
+    monitor("repo.BatchChangeJDBC.getBatchChangeCount") {
+      IO {
+        DB.readOnly { implicit s =>
+          val uid   = userId.map(u => s"user_id = '$u'")
+          val uname = userName.map(n => s"user_name = '$n'")
+          val as    = approvalStatus.map(a => s"approval_status = '${fromApprovalStatus(a)}'")
+          val dtRange = if (dateTimeStartRange.isDefined && dateTimeEndRange.isDefined)
+            Some(s"(created_time >= '${dateTimeStartRange.get}' AND created_time <= '${dateTimeEndRange.get}')")
+          else None
+
+          val extraConds = uid ++ uname ++ as ++ dtRange
+          val extraWhere = if (extraConds.nonEmpty) " AND " + extraConds.mkString(" AND ") else ""
+
+          def countSql(status: String) =
+            s"SELECT '$status' AS batch_status, COUNT(*) AS cnt FROM batch_change WHERE batch_status = '$status'$extraWhere"
+
+          val statuses = List("Complete", "Failed", "PartialFailure", "Rejected",
+                              "Cancelled", "PendingReview", "Scheduled", "PendingProcessing")
+          val unionQuery = statuses.map(countSql).mkString("\nUNION ALL\n")
+
+          val counts = SQL(unionQuery)
+            .map { res => res.string("batch_status") -> res.int("cnt") }
+            .list()
+            .apply()
+            .toMap
+
+          val complete          = counts.getOrElse("Complete", 0)
+          val failed            = counts.getOrElse("Failed", 0)
+          val partialFailure    = counts.getOrElse("PartialFailure", 0)
+          val rejected          = counts.getOrElse("Rejected", 0)
+          val cancelled         = counts.getOrElse("Cancelled", 0)
+          val pendingReview     = counts.getOrElse("PendingReview", 0)
+          val scheduled         = counts.getOrElse("Scheduled", 0)
+          val pendingProcessing = counts.getOrElse("PendingProcessing", 0)
+          BatchChangeCount(
+            total             = complete + failed + partialFailure + rejected +
+                                cancelled + pendingReview + scheduled + pendingProcessing,
+            complete          = complete,
+            failed            = failed,
+            partialFailure    = partialFailure,
+            rejected          = rejected,
+            cancelled         = cancelled,
+            pendingReview     = pendingReview,
+            scheduled         = scheduled,
+            pendingProcessing = pendingProcessing
+          )
+        }
+      }
+    }
+
   def getBatchChangeSummaries(
       userId: Option[String],
       userName: Option[String] = None,


### PR DESCRIPTION
Fixes [vinyldns#1521](https://github.com/vinyldns/vinyldns/issues/1521)
Ticket-id: VDNS-358

Adds a new API endpoint to retrieve the total count of DNS batch record changes with support for flexible filtering.

Endpoint

GET /zones/batchrecordchanges/count

Query Parameters

ignoreAccess — when set, super users can query counts across all users
userName — filter count by a specific submitter
startDateTime / endDateTime — filter by submission time range
approvalStatus — filter by approval status

Changes

Added BatchChangeCount response model
Extended BatchChangeRepository interface with getBatchChangeCount
Implemented the query in the MySQL repository with dynamic filter support
Added service-level authorization logic (user-scoped vs admin access)
Registered the route in BatchChangeRouting
Added unit tests covering normal user, super user, and filtered query scenarios