### PR TITLE
Fix DNS batch change API path and UI improvements

### DIFF
--- a/modules/frontend/conf/local.conf
+++ b/modules/frontend/conf/local.conf
@@ -1,3 +1,3 @@
 # Local development overrides — see application.conf for defaults
 # Override the port here if you need a different local port
-http.port = 9002
+http.port = 9001

--- a/modules/frontend/src/components/records/RecordHistoryModal.tsx
+++ b/modules/frontend/src/components/records/RecordHistoryModal.tsx
@@ -18,7 +18,8 @@ import React, { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { recordsService } from "../../services/recordsService";
 import { copyToClipboard } from "../../utils/dateUtils";
-import { Pagination } from "../common/Pagination";
+import { PaginatedSection } from "../common/Pagination";
+import { LoadingSpinner } from "../common/LoadingSpinner";
 
 interface RecordHistoryModalProps {
   record: any;
@@ -535,24 +536,7 @@ export function RecordHistoryModal({
                   </small>
                 </div>
               ) : isLoading ? (
-                <div
-                  className="d-flex flex-column align-items-center justify-content-center gap-3 py-5"
-                  style={{ minHeight: 220 }}
-                >
-                  <div
-                    className="spinner-border"
-                    style={{
-                      color: "#1e5fa8",
-                      width: 36,
-                      height: 36,
-                      borderWidth: "3px",
-                    }}
-                    role="status"
-                  />
-                  <span className="text-muted small">
-                    Loading change history…
-                  </span>
-                </div>
+                <LoadingSpinner />
               ) : changes.length === 0 ? (
                 <div className="vds-empty-state py-5">
                   <i
@@ -565,18 +549,14 @@ export function RecordHistoryModal({
                   </small>
                 </div>
               ) : (
-                <>
-                  {(hasPrev || hasMore) && (
-                    <div className="d-flex align-items-center justify-content-end px-3 pt-2">
-                      <Pagination
-                        onPrev={handlePrev}
-                        onNext={handleNext}
-                        prevEnabled={hasPrev}
-                        nextEnabled={hasMore}
-                        rangeLabel={`${pageIdx * 100 + 1}–${pageIdx * 100 + changes.length}`}
-                      />
-                    </div>
-                  )}
+                <PaginatedSection
+                  show={hasPrev || hasMore}
+                  onPrev={handlePrev}
+                  onNext={handleNext}
+                  prevEnabled={hasPrev}
+                  nextEnabled={hasMore}
+                  rangeLabel={`${pageIdx * 100 + 1}–${pageIdx * 100 + changes.length}`}
+                >
                   <div
                     className="vds-zones-table-wrap"
                     style={{
@@ -680,23 +660,7 @@ export function RecordHistoryModal({
                       </tbody>
                     </table>
                   </div>
-                  {(hasPrev || hasMore) && (
-                    <div
-                      className="d-flex align-items-center justify-content-end px-3 py-2"
-                      style={{
-                        borderTop: "1px solid var(--vds-card-border, #dde4ef)",
-                      }}
-                    >
-                      <Pagination
-                        onPrev={handlePrev}
-                        onNext={handleNext}
-                        prevEnabled={hasPrev}
-                        nextEnabled={hasMore}
-                        rangeLabel={`${pageIdx * 100 + 1}–${pageIdx * 100 + changes.length}`}
-                      />
-                    </div>
-                  )}
-                </>
+                </PaginatedSection>
               )}
             </div>
           </div>

--- a/modules/frontend/src/components/records/RecordsSearchTable.tsx
+++ b/modules/frontend/src/components/records/RecordsSearchTable.tsx
@@ -644,7 +644,7 @@ export function RecordsSearchTable({
                         type="button"
                         className="vds-action-btn vds-action-btn--view"
                         title="View history"
-                        onClick={() => onViewHistory(rec)}
+                        onClick={() => onViewHistory({ ...rec, fqdn: String(fqdn) })}
                       >
                         <i className="bi bi-clock-history" />
                       </button>

--- a/modules/frontend/src/pages/DnsChangesPage.tsx
+++ b/modules/frontend/src/pages/DnsChangesPage.tsx
@@ -19,7 +19,7 @@ import { useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { DnsChangesTable } from "../components/dnsChanges/DnsChangesTable";
 import { DnsChangeForm } from "../components/dnsChanges/DnsChangeForm";
-import { Pagination } from "../components/common/Pagination";
+import { PaginatedSection } from "../components/common/Pagination";
 import { LoadingSpinner } from "../components/common/LoadingSpinner";
 import { useDnsChanges } from "../hooks/useDnsChanges";
 import { useProfile } from "../contexts/ProfileContext";
@@ -155,7 +155,7 @@ export function DnsChangesPage() {
     setCancelTarget(null);
   };
 
-  // Dedicated count query — calls GET /zones/batchrecordchanges/count which
+  // Dedicated count query — calls GET /dnschange/count which
   // uses SQL COUNT queries server-side. No page-size limit; returns exact
   // totals for all matching batch changes without fetching full records.
   const { data: countData, isLoading: isCountLoading } =
@@ -220,25 +220,7 @@ export function DnsChangesPage() {
   );
 
   return (
-    <div className="position-relative">
-      {isFetching && !isLoading && (
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            zIndex: 20,
-            background: "rgba(255,255,255,0.72)",
-            backdropFilter: "blur(2px)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            borderRadius: "inherit",
-          }}
-          aria-label="Loading"
-        >
-          <LoadingSpinner />
-        </div>
-      )}
+    <div>
       <div className="rounded-3 mb-4 d-flex justify-content-between align-items-center vds-page-header">
         <div className="d-flex align-items-center gap-3">
           <div className="rounded-3 d-flex align-items-center justify-content-center vds-page-header__icon">
@@ -625,58 +607,31 @@ export function DnsChangesPage() {
         </div>
       </div>
 
-      {isLoading ? (
-        <div className="card vds-toolbar-card">
-          <LoadingSpinner />
-        </div>
+      {isLoading || isFetching ? (
+        <LoadingSpinner message="Loading changes…" />
       ) : (
-        <div className="card vds-toolbar-card overflow-hidden">
-          {(prevPageEnabled || nextPageEnabled) && (
-            <div className="d-flex align-items-center justify-content-end px-3 pt-2">
-              <Pagination
-                onPrev={prevPage}
-                onNext={nextPage}
-                prevEnabled={prevPageEnabled && !isFetching}
-                nextEnabled={nextPageEnabled && !isFetching}
-                rangeLabel={
-                  dnsChanges.length > 0
-                    ? `${(currentPage - 1) * pageSize + 1}–${(currentPage - 1) * pageSize + dnsChanges.length}`
-                    : undefined
-                }
-                totalCount={cardTotal > 0 ? cardTotal : undefined}
-              />
-            </div>
-          )}
-          <div
-            className="position-relative"
-            style={{ maxHeight: "65vh", overflowY: "auto" }}
-          >
-            <DnsChangesTable
-              changes={dnsChanges}
-              onCancel={handleCancel}
-              ignoreAccess={ignoreAccess}
-              currentUserId={currentUserId}
-              fromTab={activeTab}
-              currentPaging={paging}
-            />
-          </div>
-          {(prevPageEnabled || nextPageEnabled) && (
-            <div className="card-footer d-flex align-items-center justify-content-end py-2 px-3">
-              <Pagination
-                onPrev={prevPage}
-                onNext={nextPage}
-                prevEnabled={prevPageEnabled && !isFetching}
-                nextEnabled={nextPageEnabled && !isFetching}
-                rangeLabel={
-                  dnsChanges.length > 0
-                    ? `${(currentPage - 1) * pageSize + 1}–${(currentPage - 1) * pageSize + dnsChanges.length}`
-                    : undefined
-                }
-                totalCount={cardTotal > 0 ? cardTotal : undefined}
-              />
-            </div>
-          )}
-        </div>
+        <PaginatedSection
+          show={prevPageEnabled || nextPageEnabled}
+          onPrev={prevPage}
+          onNext={nextPage}
+          prevEnabled={prevPageEnabled}
+          nextEnabled={nextPageEnabled}
+          rangeLabel={
+            dnsChanges.length > 0
+              ? `${(currentPage - 1) * pageSize + 1}–${(currentPage - 1) * pageSize + dnsChanges.length}`
+              : undefined
+          }
+          totalCount={cardTotal > 0 ? cardTotal : undefined}
+        >
+          <DnsChangesTable
+            changes={dnsChanges}
+            onCancel={handleCancel}
+            ignoreAccess={ignoreAccess}
+            currentUserId={currentUserId}
+            fromTab={activeTab}
+            currentPaging={paging}
+          />
+        </PaginatedSection>
       )}
       {cancelTarget && (
         <div

--- a/modules/frontend/src/services/dnsChangeService.ts
+++ b/modules/frontend/src/services/dnsChangeService.ts
@@ -22,7 +22,7 @@ import type {
   CreateDnsChangeRequest,
 } from "../types/dnsChange";
 
-const BASE = "/zones/batchrecordchanges";
+const BASE = "/dnschanges";
 
 export const dnsChangeService = {
   getBatchChange(id: string) {

--- a/modules/frontend/src/test/services/dnsChangeService.test.ts
+++ b/modules/frontend/src/test/services/dnsChangeService.test.ts
@@ -43,7 +43,7 @@ const mockApi = api as unknown as {
   delete: ReturnType<typeof vi.fn>;
 };
 
-const BASE = "/zones/batchrecordchanges";
+const BASE = "/dnschanges";
 
 function buildChange(overrides: Partial<DnsChange> = {}): DnsChange {
   return {


### PR DESCRIPTION
Fixes a 404 error when creating a new DNS batch change from the React frontend.

Root Cause
The frontend dnsChangeService was calling /api/zones/batchrecordchanges directly — the internal VinylDNS API path. The portal (Play backend) does not expose that path; it proxies batch change operations under /api/dnschanges.